### PR TITLE
show request setting dailog instead of rationale dialog, when all per…

### DIFF
--- a/app/src/main/java/com/gun0912/tedpermissiondemo/RationaleActivity.java
+++ b/app/src/main/java/com/gun0912/tedpermissiondemo/RationaleActivity.java
@@ -41,6 +41,8 @@ public class RationaleActivity extends AppCompatActivity{
                 .setPermissionListener(permissionlistener)
                 .setRationaleTitle(R.string.rationale_title)
                 .setRationaleMessage(R.string.rationale_message) // "we need permission for read contact and find your location"
+                .setRequestSettingTitle("Permission required in Setting")
+                .setRequestSettingMessage("we need permission for read contact and find your location. you have to grant permission in setting.")
                 .setPermissions(Manifest.permission.READ_CONTACTS, Manifest.permission.ACCESS_FINE_LOCATION)
                 .check();
 

--- a/tedpermission/src/main/java/com/gun0912/tedpermission/TedInstance.java
+++ b/tedpermission/src/main/java/com/gun0912/tedpermission/TedInstance.java
@@ -24,6 +24,8 @@ public class TedInstance {
 
     public String deniedCloseButtonText;
     public String rationaleConfirmText;
+    public CharSequence requestSettingTitle;
+    public CharSequence requestSettingMessage;
     Context context;
 
 
@@ -53,6 +55,8 @@ public class TedInstance {
         intent.putExtra(TedPermissionActivity.EXTRA_DENIED_DIALOG_CLOSE_TEXT, deniedCloseButtonText);
         intent.putExtra(TedPermissionActivity.EXTRA_RATIONALE_CONFIRM_TEXT, rationaleConfirmText);
         intent.putExtra(TedPermissionActivity.EXTRA_SETTING_BUTTON_TEXT, settingButtonText);
+        intent.putExtra(TedPermissionActivity.EXTRA_REQUEST_SETTING_TITLE, requestSettingTitle);
+        intent.putExtra(TedPermissionActivity.EXTRA_REQUEST_SETTING_MESSAGE, requestSettingMessage);
 
 
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/tedpermission/src/main/java/com/gun0912/tedpermission/TedPermission.java
+++ b/tedpermission/src/main/java/com/gun0912/tedpermission/TedPermission.java
@@ -99,6 +99,42 @@ public class TedPermission {
         return this;
     }
 
+    public TedPermission setRequestSettingMessage(String requestSettingMessage) {
+
+        instance.requestSettingMessage = requestSettingMessage;
+        return this;
+    }
+
+
+    public TedPermission setRequestSettingMessage(@StringRes int stringRes) {
+
+        if (stringRes <= 0)
+            throw new IllegalArgumentException("Invalid value for DeniedMessage");
+
+        instance.requestSettingMessage = instance.context.getText(stringRes);
+        return this;
+    }
+
+
+
+    public TedPermission setRequestSettingTitle(String requestSettingTitle) {
+
+        instance.requestSettingTitle = requestSettingTitle;
+        return this;
+    }
+
+
+    public TedPermission setRequestSettingTitle(@StringRes int stringRes) {
+
+        if (stringRes <= 0)
+            throw new IllegalArgumentException("Invalid value for DeniedTitle");
+
+        instance.requestSettingTitle = instance.context.getText(stringRes);
+        return this;
+    }
+
+
+
     public TedPermission setGotoSettingButton(boolean hasSettingBtn) {
 
         instance.hasSettingBtn = hasSettingBtn;


### PR DESCRIPTION
모든 퍼미션을 다시보지않기 누른 후 거부하게 되면, 
ActivityCompat.requestPermissions()을 사용하면 아무런 동작을 하지 않습니다.
따라서 이런 경우에 rationale dialog만 뜨고 아무런 permission 요청을 하지 않는 경우가 생기는데
이런 경우 setting 창에서 설정하라는 기존deny dailog와 유사하게 만들었습니다.