### PR TITLE
#59 fix NullPointerException when call twice.

### DIFF
--- a/tedpermission/src/main/java/com/gun0912/tedpermission/TedPermissionActivity.java
+++ b/tedpermission/src/main/java/com/gun0912/tedpermission/TedPermissionActivity.java
@@ -54,8 +54,11 @@ public class TedPermissionActivity extends AppCompatActivity {
     boolean isShownRationaleDialog;
 
     public static void startActivity(Context context, Intent intent, PermissionListener listener) {
-        context.startActivity(intent);
+        if(TedPermissionActivity.listener != null) {
+            throw new RuntimeException("You can not make the next request until the previous request has been completed.")
+        }
         TedPermissionActivity.listener = listener;
+        context.startActivity(intent);
     }
 
     @Override
@@ -176,6 +179,10 @@ public class TedPermissionActivity extends AppCompatActivity {
 
     private void permissionResult(ArrayList<String> deniedPermissions) {
         Log.v(TedPermission.TAG, "permissionResult(): " + deniedPermissions);
+
+        if(TedPermissionActivity.listener == null) {
+            throw new RuntimeException("listener cannot be null");
+        }
 
         if (ObjectUtils.isEmpty(deniedPermissions)) {
             TedPermissionActivity.listener.onPermissionGranted();


### PR DESCRIPTION
아래 코드와 같이 권한요청을 두번보내거나 이전 요청이 끝나기전에 두번째 요청을 보내면,
```java
            TedPermission.with(context)
                    .setPermissionListener(listener)
                    .setPermissions(permissionString)
                    .check();
            TedPermission.with(context)
                    .setPermissionListener(listener)
                    .setPermissions(permissionString)
                    .check();
```

`listener` 하나에 두번 덮어씌워지게 되고,
첫번째 요청이 끝나면 listener를 null로 만들게됩니다.
두번째 요청은 null인 listener를 참조하게 되어 결국엔 NullPointerException이 나게됩니다.
#59 이슈도 이 문제인것 같습니다.

====
If you send a permission request twice, or send a second request before the end of the previous request as in the code below,  
`listener` is overwritten twice,
At the end of the first request, the `listener` will be null.
The second request references a null listener and throws a NullPointerException.
I think #59 is related with this problem.