### PR TITLE
#63 fix orientation issue in sdk 26

### DIFF
--- a/tedpermission/src/main/AndroidManifest.xml
+++ b/tedpermission/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
         <activity
             android:name=".TedPermissionActivity"
             android:configChanges="mcc|mnc|locale|keyboard|keyboardHidden|screenLayout|fontScale|uiMode|orientation|screenSize|layoutDirection"
-            android:screenOrientation="portrait"
+            android:screenOrientation="unspecified"
             android:theme="@style/Theme.Transparent.Permission"
             />
 

--- a/tedpermission/src/main/java/com/gun0912/tedpermission/PermissionBuilder.java
+++ b/tedpermission/src/main/java/com/gun0912/tedpermission/PermissionBuilder.java
@@ -2,6 +2,7 @@ package com.gun0912.tedpermission;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
 import android.os.Build;
 import android.support.annotation.StringRes;
 
@@ -24,12 +25,14 @@ public abstract class PermissionBuilder<T extends PermissionBuilder> {
 
     private CharSequence deniedCloseButtonText;
     private CharSequence rationaleConfirmText;
+    private int requestedOrientation;
     private Context context;
 
     public PermissionBuilder(Context context) {
         this.context = context;
         deniedCloseButtonText = context.getString(R.string.tedpermission_close);
         rationaleConfirmText = context.getString(R.string.tedpermission_confirm);
+        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED;
     }
 
     protected void checkPermissions() {
@@ -56,6 +59,7 @@ public abstract class PermissionBuilder<T extends PermissionBuilder> {
         intent.putExtra(TedPermissionActivity.EXTRA_DENIED_DIALOG_CLOSE_TEXT, deniedCloseButtonText);
         intent.putExtra(TedPermissionActivity.EXTRA_RATIONALE_CONFIRM_TEXT, rationaleConfirmText);
         intent.putExtra(TedPermissionActivity.EXTRA_SETTING_BUTTON_TEXT, settingButtonText);
+        intent.putExtra(TedPermissionActivity.EXTRA_SCREEN_ORIENTATION, requestedOrientation);
 
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         intent.addFlags(Intent.FLAG_ACTIVITY_NO_USER_ACTION);
@@ -147,6 +151,11 @@ public abstract class PermissionBuilder<T extends PermissionBuilder> {
 
     public T setDeniedCloseButtonText(@StringRes int stringRes) {
         return setDeniedCloseButtonText(getText(stringRes));
+    }
+
+    public T setScreenOrientation(int requestedOrientation) {
+        this.requestedOrientation = requestedOrientation;
+        return (T) this;
     }
 
 }

--- a/tedpermission/src/main/java/com/gun0912/tedpermission/TedPermissionActivity.java
+++ b/tedpermission/src/main/java/com/gun0912/tedpermission/TedPermissionActivity.java
@@ -5,6 +5,7 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
 import android.net.Uri;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
@@ -42,6 +43,7 @@ public class TedPermissionActivity extends AppCompatActivity {
     public static final String EXTRA_SETTING_BUTTON_TEXT = "setting_button_text";
     public static final String EXTRA_RATIONALE_CONFIRM_TEXT = "rationale_confirm_text";
     public static final String EXTRA_DENIED_DIALOG_CLOSE_TEXT = "denied_dialog_close_text";
+    public static final String EXTRA_SCREEN_ORIENTATION = "screen_orientation";
     private static Deque<PermissionListener> permissionListenerStack;
     CharSequence rationaleTitle;
     CharSequence rationale_message;
@@ -54,6 +56,7 @@ public class TedPermissionActivity extends AppCompatActivity {
     String deniedCloseButtonText;
     String rationaleConfirmText;
     boolean isShownRationaleDialog;
+    int requestedOrientation;
 
     public static void startActivity(Context context, Intent intent, PermissionListener listener) {
         if (permissionListenerStack == null) {
@@ -75,6 +78,8 @@ public class TedPermissionActivity extends AppCompatActivity {
         } else {
             checkPermissions(false);
         }
+
+        setRequestedOrientation(requestedOrientation);
     }
 
 
@@ -93,6 +98,7 @@ public class TedPermissionActivity extends AppCompatActivity {
             deniedCloseButtonText = savedInstanceState.getString(EXTRA_DENIED_DIALOG_CLOSE_TEXT);
 
             settingButtonText = savedInstanceState.getString(EXTRA_SETTING_BUTTON_TEXT);
+            requestedOrientation = savedInstanceState.getInt(EXTRA_SCREEN_ORIENTATION);
         } else {
 
             Intent intent = getIntent();
@@ -106,6 +112,7 @@ public class TedPermissionActivity extends AppCompatActivity {
             rationaleConfirmText = intent.getStringExtra(EXTRA_RATIONALE_CONFIRM_TEXT);
             deniedCloseButtonText = intent.getStringExtra(EXTRA_DENIED_DIALOG_CLOSE_TEXT);
             settingButtonText = intent.getStringExtra(EXTRA_SETTING_BUTTON_TEXT);
+            requestedOrientation = intent.getIntExtra(EXTRA_SCREEN_ORIENTATION, ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
 
         }
 


### PR DESCRIPTION
related with #63 

Since android 'O'(26), we should satisfy following condition.

```java
if (ActivityInfo.isFixedOrientation(requestedOrientation) && !fullscreen
                 && appInfo.targetSdkVersion >= O) {
             throw new IllegalStateException("Only fullscreen activities can request orientation");
         }
```
(detail info is [here](https://github.com/aosp-mirror/platform_frameworks_base/commit/39791594560b2326625b663ed6796882900c220f#diff-960c6fdd4a4b336d98b785268b2a78ff) )

We don't know which direction the application using this library will use. 
So we should support all direction. 
And it should be able to change when the user needs it.

So, I changed `TedPermissionActivity`'s screen orientation to `unspecified`. 
And create `setScreenOrientation` method at `PermissionBuilder`
  
thanks to @andreas-
