### PR TITLE
Support SYSTEM_ALERT_WINDOW permission

### DIFF
--- a/app/src/main/java/com/gun0912/tedpermissiondemo/WindowPermissionActivity.java
+++ b/app/src/main/java/com/gun0912/tedpermissiondemo/WindowPermissionActivity.java
@@ -4,6 +4,7 @@ import android.Manifest;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.widget.Toast;
 import com.gun0912.tedpermission.PermissionListener;
 import com.gun0912.tedpermission.TedPermission;
@@ -12,12 +13,14 @@ import java.util.List;
 /**
  * Created by babosamo on 16. 10. 4..
  */
-public class WindowPermissionActivity extends AppCompatActivity{
+public class WindowPermissionActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        boolean isAlertWindowPermissionGranted = TedPermission.isGranted(this, Manifest.permission.SYSTEM_ALERT_WINDOW);
+        Log.d("ted", "isAlertWindowPermissionGranted: " + isAlertWindowPermissionGranted);
 
 
         PermissionListener permissionlistener = new PermissionListener() {

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,10 @@ buildscript {
     repositories {
         jcenter()
         mavenCentral()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
 
     }
     dependencies {
@@ -24,6 +28,10 @@ allprojects {
     repositories {
         jcenter()
         mavenCentral()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 
     group = GROUP

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@
 # org.gradle.parallel=true
 
 GROUP=gun0912.ted
-VERSION_NAME=2.2.2
+VERSION_NAME=2.2.3
 
 DEVELOPER_ID='gun0912'
 DEVELOPER_NAME='Ted Park'

--- a/tedpermission/src/main/java/com/gun0912/tedpermission/TedPermissionBase.java
+++ b/tedpermission/src/main/java/com/gun0912/tedpermission/TedPermissionBase.java
@@ -1,11 +1,13 @@
 package com.gun0912.tedpermission;
 
+import android.Manifest;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.net.Uri;
+import android.os.Build;
 import android.provider.Settings;
 import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
@@ -38,7 +40,15 @@ public abstract class TedPermissionBase {
     }
 
     private static boolean isGranted(Context context, @NonNull String permission) {
-        return ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED;
+        if (permission.equals(Manifest.permission.SYSTEM_ALERT_WINDOW)) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                return Settings.canDrawOverlays(context);
+            } else {
+                return true;
+            }
+        } else {
+            return ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED;
+        }
     }
 
     public static List<String> getDeniedPermissions(Context context, @NonNull String... permissions) {


### PR DESCRIPTION
- When we want check `SYSTEM_ALERT_WINDOW` permission, we will use `isGranted()` method
- But this method not work until v2.2.2
- So this PR is support SYSTEM_ALERT_WINDOW permission
 