### PR TITLE
Fix deprecated startActivityForResult and add request Allow access to manage all files

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.gun0912.tedpermissiondemo">
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
     <application

--- a/tedpermission/src/main/java/com/gun0912/tedpermission/TedPermissionActivity.java
+++ b/tedpermission/src/main/java/com/gun0912/tedpermission/TedPermissionActivity.java
@@ -37,6 +37,7 @@ public class TedPermissionActivity extends AppCompatActivity {
     public static final int REQ_CODE_SYSTEM_ALERT_WINDOW_PERMISSION_REQUEST = 30;
     public static final int REQ_CODE_SYSTEM_ALERT_WINDOW_PERMISSION_REQUEST_SETTING = 31;
     public static final int REQ_CODE_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION_REQUEST = 32;
+    public static final int REQ_CODE_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION_REQUEST_SETTING = 33;
 
 
     public static final String EXTRA_PERMISSIONS = "permissions";
@@ -99,13 +100,20 @@ public class TedPermissionActivity extends AppCompatActivity {
                             if (!hasWindowPermission() && !TextUtils.isEmpty(denyMessage)) {  // 권한이 거부되고 denyMessage 가 있는 경우
                                 showWindowPermissionDenyDialog();
                             } else {     // 권한있거나 또는 denyMessage가 없는 경우는 일반 permission 을 확인한다.
-                                checkPermissions(false);
+                                checkPermissionSetting();
                             }
                             break;
                         case REQ_CODE_SYSTEM_ALERT_WINDOW_PERMISSION_REQUEST_SETTING:   //  ALERT WINDOW 권한 설정 실패후 재 요청에 대한 결과
                             checkPermissionSetting();
                             break;
                         case REQ_CODE_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION_REQUEST:
+                            if (!hasExternalStorageManagerPermission() && !TextUtils.isEmpty(denyMessage)) {
+                                showExternalStorageManagerPermissionDenyDialog();
+                            } else {
+                                checkPermissionSetting();
+                            }
+                            break;
+                        case REQ_CODE_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION_REQUEST_SETTING:
                             checkPermissionSetting();
                             break;
                     }
@@ -454,6 +462,40 @@ public class TedPermissionActivity extends AppCompatActivity {
             requestCode = REQ_CODE_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION_REQUEST;
             startActivityForResultLauncher.launch(intent);
         }
+    }
+
+    @TargetApi(VERSION_CODES.R)
+    public void showExternalStorageManagerPermissionDenyDialog() {
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.Theme_AppCompat_Light_Dialog_Alert);
+        builder.setMessage(denyMessage)
+                .setCancelable(false)
+                .setNegativeButton(deniedCloseButtonText, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        checkPermissions(false);
+                    }
+                });
+
+        if (hasSettingButton) {
+            if (TextUtils.isEmpty(settingButtonText)) {
+                settingButtonText = getString(R.string.tedpermission_setting);
+            }
+
+            final Intent intent = new Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION);
+            intent.addCategory("android.intent.category.DEFAULT");
+            intent.setData(Uri.parse(String.format("package:%s",this.getPackageName())));
+
+            builder.setPositiveButton(settingButtonText, new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    requestCode = REQ_CODE_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION_REQUEST;
+                    startActivityForResultLauncher.launch(intent);
+                }
+            });
+
+        }
+        builder.show();
     }
 
     @Override

--- a/tedpermission/src/main/java/com/gun0912/tedpermission/TedPermissionUtil.java
+++ b/tedpermission/src/main/java/com/gun0912/tedpermission/TedPermissionUtil.java
@@ -11,10 +11,10 @@ import android.net.Uri;
 import android.os.Build;
 import android.provider.Settings;
 
+import androidx.activity.result.ActivityResultLauncher;
 import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
-import androidx.fragment.app.Fragment;
 
 import com.gun0912.tedpermission.provider.TedPermissionProvider;
 
@@ -112,24 +112,12 @@ public class TedPermissionUtil {
         return context.getSharedPreferences(PREFS_NAME_PERMISSION, Context.MODE_PRIVATE);
     }
 
-    public static void startSettingActivityForResult(Activity activity) {
-        startSettingActivityForResult(activity, REQ_CODE_REQUEST_SETTING);
-    }
-
-    public static void startSettingActivityForResult(Activity activity, int requestCode) {
-        activity.startActivityForResult(getSettingIntent(), requestCode);
+    public static void startSettingActivityForResult(ActivityResultLauncher<Intent> startActivityForResultLauncher) {
+        startActivityForResultLauncher.launch(getSettingIntent());
     }
 
     public static Intent getSettingIntent() {
         return new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).setData(Uri.parse("package:" + context.getPackageName()));
-    }
-
-    public static void startSettingActivityForResult(Fragment fragment) {
-        startSettingActivityForResult(fragment, REQ_CODE_REQUEST_SETTING);
-    }
-
-    public static void startSettingActivityForResult(Fragment fragment, int requestCode) {
-        fragment.startActivityForResult(getSettingIntent(), requestCode);
     }
 
     static void setFirstRequest(@NonNull String[] permissions) {


### PR DESCRIPTION
- Fix deprecated startActivityForResult and use ActivityResultLauncher
- Add request Allow access to manage all files for android above version code R to allows the app to manage files on the device’s external storage without restrictions, bypassing the Scoped Storage rules introduced in Android 10.

References :
[https://developer.android.com/training/basics/intents/result](url)
[https://developer.android.com/training/data-storage/manage-all-files](url)